### PR TITLE
Add usage instructions to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Read more details on the feature here:
 
 [![Build Status](https://travis-ci.org/rwjblue/ember-runtime-enumerable-includes-polyfill.svg?branch=master)](https://travis-ci.org/rwjblue/ember-runtime-enumerable-includes-polyfill)
 
+## Usage
+To use this addon in your project, install it as a runtime dependency:
+
+```bash
+npm install --save ember-runtime-enumerable-includes-polyfill
+```
+
+That's it!
+
 ## Installation
 
 * `git clone <repository-url>` this repository


### PR DESCRIPTION
I had to dig through the implementation to make sure that including as a runtime dep was all I needed to do.
