### PR TITLE
Avoid errors if Ember version cannot be determined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ module.exports = {
       importContext = this._findHostForLegacyEmberCLI();
     }
 
-    if (this._getEmberVersion().lt('2.8.0-beta.1')) {
+    var emberVersion = this._getEmberVersion();
+
+    if (emberVersion && emberVersion.lt('2.8.0-beta.1')) {
       importContext.import('vendor/enumerable-includes-polyfill/index.js');
     }
   },
@@ -29,7 +31,13 @@ module.exports = {
       return emberVersionChecker;
     }
 
-    return checker.for('ember-source', 'npm');
+    emberVersionChecker = checker.for('ember-source', 'npm');
+
+    if (emberVersionChecker.version) {
+      return emberVersionChecker;
+    }
+
+    this.ui.writeLine('[ember-runtime-enumerable-includes-polyfill] Cannot identify Ember version to determine if polyfill is needed.');
   },
 
   // included from https://git.io/v6F7n


### PR DESCRIPTION
This is somewhat annoying, but at least it will warn you properly (instead of throwing with a horrible stack) when it is not sure if you need the polyfill.

It defaults to not including the polyfill if the Ember version cannot be determined.

Fixes #4.