### PR TITLE
Update to use Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/rwjblue/ember-runtime-enumerable-includes-polyfill.git"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Robert Jackson <me@rwjblue.com>",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.1.0",
@@ -46,7 +46,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^1.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
This will be a major version bump due to ember-cli-babel@6 requiring Node 4.