### PR TITLE
Updated `ember-cli-dependency-checker` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-ajax": "^2.0.1",
     "ember-cli": "2.8.0-beta.2",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
+    "ember-cli-dependency-checker": "^2.1.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.0",


### PR DESCRIPTION
This causes warnings while building and running `ember s`